### PR TITLE
Add new exposure keys buckets to support Google/Apple tracing API

### DIFF
--- a/config_file.tf
+++ b/config_file.tf
@@ -4,20 +4,22 @@ resource "google_storage_bucket_object" "config_file" {
   cache_control = "private"
 
   content = jsonencode({
-    "aggS2Index" = 0
-    "aggS2Levels" = [8, 10, 12]
-    "archiveBucket" = google_storage_bucket.archive.name
-    "compareS2Level" = 18
-    "elevatedNotaryUrl" = google_cloudfunctions_function.notary.https_trigger_url
-    "exposureBucket" = google_storage_bucket.exposures.name
-    "exposureS2Level" = 10
-    "holdingBucket" = google_storage_bucket.locations.name
-    "notaryUrl" = google_cloudfunctions_function.notary.https_trigger_url
-    "operatorUrl" = google_cloudfunctions_function.operator.https_trigger_url
-    "publishedBucket" = google_storage_bucket.publish.name
-    "reportS2Level" = 22
-    "symptomBucket" = google_storage_bucket.symptoms.name
-    "timeResolution" = 15
-    "tokenBucket" = google_storage_bucket.bluetooth.name
+    "aggS2Index"                  = 0
+    "aggS2Levels"                 = [8, 10, 12]
+    "archiveBucket"               = google_storage_bucket.archive.name
+    "compareS2Level"              = 18
+    "elevatedNotaryUrl"           = google_cloudfunctions_function.notary.https_trigger_url
+    "exposureBucket"              = google_storage_bucket.exposures.name
+    "exposureS2Level"             = 10
+    "holdingBucket"               = google_storage_bucket.locations.name
+    "notaryUrl"                   = google_cloudfunctions_function.notary.https_trigger_url
+    "operatorUrl"                 = google_cloudfunctions_function.operator.https_trigger_url
+    "publishedBucket"             = google_storage_bucket.publish.name
+    "reportS2Level"               = 22
+    "symptomBucket"               = google_storage_bucket.symptoms.name
+    "timeResolution"              = 15
+    "tokenBucket"                 = google_storage_bucket.bluetooth.name
+    "exposureKeysHoldingBucket"   = google_storage_bucket.exposure_keys_holding.name
+    "exposureKeysPublishedBucket" = google_storage_bucket.exposure_keys_published.name
   })
 }

--- a/storage.tf
+++ b/storage.tf
@@ -115,6 +115,53 @@ resource "google_storage_bucket_iam_member" "bluetooth_cloudrun" {
   member = "serviceAccount:${google_service_account.cloudrun.email}"
 }
 
+resource "google_storage_bucket" "exposure_keys_holding" {
+  name               = "covidtrace-exposure-keys-holding"
+  location           = "US"
+  force_destroy      = true
+  bucket_policy_only = false
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = 1
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "exposure_keys_notary" {
+  bucket = google_storage_bucket.exposure_keys_holding.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.notary.email}"
+}
+
+resource "google_storage_bucket_iam_member" "exposure_keys_cloudrun" {
+  bucket = google_storage_bucket.exposure_keys_holding.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+resource "google_storage_bucket" "exposure_keys_published" {
+  name               = "covidtrace-exposure-keys-published"
+  location           = "US"
+  force_destroy      = true
+  bucket_policy_only = false
+}
+
+resource "google_storage_bucket_iam_member" "exposure_keys_publish_cloudrun" {
+  bucket = google_storage_bucket.exposure_keys_published.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloudrun.email}"
+}
+
+resource "google_storage_bucket_iam_member" "exposure_keys_publish_allusers" {
+  bucket = google_storage_bucket.exposure_keys_published.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
 resource "google_storage_bucket" "publish" {
   name               = "covidtrace-published"
   location           = "US"


### PR DESCRIPTION
Adds two new buckets
```
covidtrace-exposure-keys-holding
covidtrace-exposure-keys-published
```

with appropriate permissions. Will have a PR to update the aggregator next